### PR TITLE
Feat/galxe

### DIFF
--- a/config.template.toml
+++ b/config.template.toml
@@ -1,8 +1,12 @@
 [server]
 port = 8080
 
-[database]
+[databases]
+[databases.starknetid]
 name = "starknetid"
+connection_string = "xxxxxx"
+[databases.sales]
+name = "sales"
 connection_string = "xxxxxx"
 
 [contracts]

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,16 +15,11 @@ macro_rules! pub_struct {
 pub_struct!(Server { port: u16, });
 
 pub_struct!(Databases {
-    starknetid: StarknetidDb,
-    sales: SalesDb,
+    starknetid: Database,
+    sales: Database,
 });
 
-pub_struct!(StarknetidDb {
-    name: String,
-    connection_string: String,
-});
-
-pub_struct!(SalesDb {
+pub_struct!(Database {
     name: String,
     connection_string: String,
 });

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,7 +14,17 @@ macro_rules! pub_struct {
 
 pub_struct!(Server { port: u16, });
 
-pub_struct!(Database {
+pub_struct!(Databases {
+    starknetid: StarknetidDb,
+    sales: SalesDb,
+});
+
+pub_struct!(StarknetidDb {
+    name: String,
+    connection_string: String,
+});
+
+pub_struct!(SalesDb {
     name: String,
     connection_string: String,
 });
@@ -29,7 +39,7 @@ pub_struct!(Contracts {
 
 pub_struct!(Config {
     server: Server,
-    database: Database,
+    databases: Databases,
     contracts: Contracts,
 });
 

--- a/src/endpoints/addr_to_available_ids.rs
+++ b/src/endpoints/addr_to_available_ids.rs
@@ -29,8 +29,8 @@ pub async fn handler(
     State(state): State<Arc<AppState>>,
     Query(query): Query<AddrQuery>,
 ) -> impl IntoResponse {
-    let starknet_ids = state.db.collection::<mongodb::bson::Document>("id_owners");
-    let domains = state.db.collection::<mongodb::bson::Document>("domains");
+    let starknet_ids = state.starknetid_db.collection::<mongodb::bson::Document>("id_owners");
+    let domains = state.starknetid_db.collection::<mongodb::bson::Document>("domains");
     let addr = to_hex(&query.addr);
     let documents = starknet_ids
         .find(

--- a/src/endpoints/addr_to_domain.rs
+++ b/src/endpoints/addr_to_domain.rs
@@ -28,7 +28,7 @@ pub async fn handler(
     State(state): State<Arc<AppState>>,
     Query(query): Query<AddrToDomainQuery>,
 ) -> impl IntoResponse {
-    let domains = state.db.collection::<mongodb::bson::Document>("domains");
+    let domains = state.starknetid_db.collection::<mongodb::bson::Document>("domains");
     let hex_addr = to_hex(&query.addr);
     let document = domains
         .find_one(

--- a/src/endpoints/addr_to_external_domains.rs
+++ b/src/endpoints/addr_to_external_domains.rs
@@ -23,7 +23,7 @@ pub async fn handler(
     State(state): State<Arc<AppState>>,
     Query(query): Query<DomainQuery>,
 ) -> impl IntoResponse {
-    let subdomains = state.db.collection::<mongodb::bson::Document>("subdomains");
+    let subdomains = state.starknetid_db.collection::<mongodb::bson::Document>("subdomains");
     let addr = &query.addr;
     let mut domains_list = Vec::new();
 

--- a/src/endpoints/addr_to_full_ids.rs
+++ b/src/endpoints/addr_to_full_ids.rs
@@ -40,7 +40,7 @@ pub async fn handler(
     State(state): State<Arc<AppState>>,
     Query(query): Query<AddrQuery>,
 ) -> impl IntoResponse {
-    let id_owners = state.db.collection::<mongodb::bson::Document>("id_owners");
+    let id_owners = state.starknetid_db.collection::<mongodb::bson::Document>("id_owners");
 
     let pipeline = vec![
         doc! {

--- a/src/endpoints/addr_to_token_id.rs
+++ b/src/endpoints/addr_to_token_id.rs
@@ -26,7 +26,7 @@ pub async fn handler(
     State(state): State<Arc<AppState>>,
     Query(query): Query<TokenIdQuery>,
 ) -> impl IntoResponse {
-    let domains = state.db.collection::<mongodb::bson::Document>("domains");
+    let domains = state.starknetid_db.collection::<mongodb::bson::Document>("domains");
     let addr = to_hex(&query.addr);
 
     let document = domains

--- a/src/endpoints/addrs_to_domains.rs
+++ b/src/endpoints/addrs_to_domains.rs
@@ -28,7 +28,7 @@ pub async fn handler(
     State(state): State<Arc<AppState>>,
     Json(query): Json<AddrToDomainsQuery>,
 ) -> impl IntoResponse {
-    let domains = state.db.collection::<mongodb::bson::Document>("domains");
+    let domains = state.starknetid_db.collection::<mongodb::bson::Document>("domains");
 
     let addresses: Vec<String> = query.addresses.iter().map(|addr| to_hex(addr)).collect();
 

--- a/src/endpoints/data_to_ids.rs
+++ b/src/endpoints/data_to_ids.rs
@@ -25,7 +25,7 @@ pub async fn handler(
     Query(query): Query<StarknetIdQuery>,
 ) -> impl IntoResponse {
     let ids_data = state
-        .db
+        .starknetid_db
         .collection::<mongodb::bson::Document>("starknet_ids_data");
 
     let document = ids_data

--- a/src/endpoints/domain_to_addr.rs
+++ b/src/endpoints/domain_to_addr.rs
@@ -30,7 +30,7 @@ pub async fn handler(
         // todo: handle subdomains
         get_error("unhandled".to_string())
     } else {
-        let domains = state.db.collection::<mongodb::bson::Document>("domains");
+        let domains = state.starknetid_db.collection::<mongodb::bson::Document>("domains");
         let document = domains
             .find_one(
                 doc! {

--- a/src/endpoints/domain_to_data.rs
+++ b/src/endpoints/domain_to_data.rs
@@ -26,7 +26,7 @@ pub async fn handler(
     let mut headers = HeaderMap::new();
     headers.insert("Cache-Control", HeaderValue::from_static("max-age=30"));
 
-    let domains = state.db.collection::<mongodb::bson::Document>("domains");
+    let domains = state.starknetid_db.collection::<mongodb::bson::Document>("domains");
     match get_custom_resolver(&domains, &query.domain).await {
         None => {}
         Some(res) => {
@@ -35,7 +35,7 @@ pub async fn handler(
         }
     }
 
-    let starknet_ids = state.db.collection::<mongodb::bson::Document>("id_owners");
+    let starknet_ids = state.starknetid_db.collection::<mongodb::bson::Document>("id_owners");
 
     let domain_document = domains
         .find_one(
@@ -98,7 +98,7 @@ pub async fn handler(
         },
     ];
 
-    let starknet_ids_data = state.db.collection::<Document>("id_verifier_data");
+    let starknet_ids_data = state.starknetid_db.collection::<Document>("id_verifier_data");
     let results = starknet_ids_data.aggregate(pipeline, None).await;
 
     let mut github = None;

--- a/src/endpoints/galxe.rs
+++ b/src/endpoints/galxe.rs
@@ -1,0 +1,1 @@
+pub mod verify;

--- a/src/endpoints/galxe/verify.rs
+++ b/src/endpoints/galxe/verify.rs
@@ -1,0 +1,65 @@
+use std::sync::Arc;
+
+use crate::models::AppState;
+use axum::{extract::State, http::StatusCode, response::IntoResponse, Json};
+use futures::StreamExt;
+use mongodb::{bson::doc, bson::Document};
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize)]
+pub struct EmailQuery {
+    email: String,
+}
+
+#[derive(Serialize)]
+pub struct SimpleResponse {
+    result: &'static str,
+}
+
+pub async fn handler(
+    State(state): State<Arc<AppState>>,
+    Json(query): Json<EmailQuery>,
+) -> impl IntoResponse {
+    // Get the metadata collection
+    let metadata_collection = state.sales_db.collection::<Document>("metadata");
+
+    // Define the aggregation pipeline with a lookup stage
+    let pipeline = vec![
+        doc! {
+            "$match": {
+                "email": &query.email
+            }
+        },
+        doc! {
+            "$lookup": {
+                "from": "processed",
+                "localField": "meta_hash",
+                "foreignField": "meta_hash",
+                "as": "matched_docs"
+            }
+        },
+        doc! {
+            "$match": {
+                "matched_docs": {
+                    "$ne": []
+                }
+            }
+        },
+    ];
+
+    // Execute the aggregation pipeline
+    let mut cursor = metadata_collection.aggregate(pipeline, None).await.unwrap();
+
+    // Check if any results are returned
+    if cursor.next().await.is_some() {
+        let response = SimpleResponse {
+            result: "0x00000000000000000000000000000001",
+        };
+        return (StatusCode::OK, Json(response)).into_response();
+    } else {
+        let response = SimpleResponse {
+            result: "0x00000000000000000000000000000000",
+        };
+        return (StatusCode::OK, Json(response)).into_response();
+    }
+}

--- a/src/endpoints/id_to_data.rs
+++ b/src/endpoints/id_to_data.rs
@@ -26,8 +26,8 @@ pub async fn handler(
     let mut headers = HeaderMap::new();
     headers.insert("Cache-Control", HeaderValue::from_static("max-age=30"));
 
-    let domains = state.db.collection::<mongodb::bson::Document>("domains");
-    let starknet_ids = state.db.collection::<mongodb::bson::Document>("id_owners");
+    let domains = state.starknetid_db.collection::<mongodb::bson::Document>("domains");
+    let starknet_ids = state.starknetid_db.collection::<mongodb::bson::Document>("id_owners");
 
     let hex_id = to_hex(&query.id);
 
@@ -107,7 +107,7 @@ pub async fn handler(
         },
     ];
 
-    let starknet_ids_data = state.db.collection::<Document>("id_verifier_data");
+    let starknet_ids_data = state.starknetid_db.collection::<Document>("id_verifier_data");
     let results = starknet_ids_data.aggregate(pipeline, None).await;
 
     let mut github = None;

--- a/src/endpoints/mod.rs
+++ b/src/endpoints/mod.rs
@@ -7,6 +7,7 @@ pub mod addrs_to_domains;
 pub mod data_to_ids;
 pub mod domain_to_addr;
 pub mod domain_to_data;
+pub mod galxe;
 pub mod id_to_data;
 pub mod referral;
 pub mod uri;

--- a/src/endpoints/referral/add_click.rs
+++ b/src/endpoints/referral/add_click.rs
@@ -23,7 +23,7 @@ pub async fn handler(
     Json(query): Json<AddClickQuery>,
 ) -> impl IntoResponse {
     let sponsor_usage = state
-        .db
+        .starknetid_db
         .collection::<mongodb::bson::Document>("sponsor_usage");
     let update_options = UpdateOptions::builder().upsert(true).build();
 

--- a/src/endpoints/referral/click_count.rs
+++ b/src/endpoints/referral/click_count.rs
@@ -30,7 +30,7 @@ pub async fn handler(
     headers.insert("Cache-Control", HeaderValue::from_static("max-age=30"));
 
     let sponsor_usage = state
-        .db
+        .starknetid_db
         .collection::<mongodb::bson::Document>("sponsor_usage");
 
     let mut output = Data { counts: vec![] };

--- a/src/endpoints/referral/revenue.rs
+++ b/src/endpoints/referral/revenue.rs
@@ -30,7 +30,7 @@ pub async fn handler(
     headers.insert("Cache-Control", HeaderValue::from_static("max-age=30"));
 
     let referral_revenues = state
-        .db
+        .starknetid_db
         .collection::<mongodb::bson::Document>("referral_revenues");
 
     let mut output = Data { revenues: vec![] };

--- a/src/endpoints/referral/sales_count.rs
+++ b/src/endpoints/referral/sales_count.rs
@@ -30,7 +30,7 @@ pub async fn handler(
     headers.insert("Cache-Control", HeaderValue::from_static("max-age=30"));
 
     let referral_revenues = state
-        .db
+        .starknetid_db
         .collection::<mongodb::bson::Document>("referral_revenues");
 
     let mut output = Data { counts: vec![] };

--- a/src/endpoints/uri.rs
+++ b/src/endpoints/uri.rs
@@ -37,7 +37,7 @@ pub async fn handler(
     State(state): State<Arc<AppState>>,
     Query(query): Query<TokenIdQuery>,
 ) -> impl IntoResponse {
-    let domains = state.db.collection::<mongodb::bson::Document>("domains");
+    let domains = state.starknetid_db.collection::<mongodb::bson::Document>("domains");
 
     let document = domains
         .find_one(

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,16 +37,14 @@ async fn main() {
             .unwrap()
             .database(&conf.databases.sales.name),
     });
-    if shared_state
-        .starknetid_db
-        .run_command(doc! {"ping": 1}, None)
-        .await
-        .is_err()
-    {
-        println!("error: unable to connect to database");
-        return;
-    } else {
-        println!("database: connected")
+    // we will know by looking at the log number which db has an issue
+    for db in [&shared_state.starknetid_db, &shared_state.sales_db] {
+        if db.run_command(doc! {"ping": 1}, None).await.is_err() {
+            println!("error: unable to connect to a database");
+            return;
+        } else {
+            println!("database: connected")
+        }
     }
 
     let cors = CorsLayer::new().allow_headers(Any).allow_origin(Any);

--- a/src/models.rs
+++ b/src/models.rs
@@ -5,7 +5,8 @@ use serde::Serialize;
 
 pub struct AppState {
     pub conf: Config,
-    pub db: Database,
+    pub starknetid_db: Database,
+    pub sales_db: Database,
 }
 
 #[derive(Serialize)]


### PR DESCRIPTION
# Add New `/galxe/verify` POST Endpoint

This PR introduces a new endpoint `/galxe/verify` for verifying sales linked to an email address. It is intended to be used  by the Galxe backend.

## Usage:

Make a POST request with a JSON payload containing the email you wish to verify:

```json
{
    "email": "your_email_here@domain.com"
}
```

The endpoint will return:

- `"0x00000000000000000000000000000001"` if a sale is found with the specified email.
- `"0x00000000000000000000000000000000"` otherwise.

## Examples:

### 1. Verifying a known email:

```json
    {
        "email": "thomas@starknet.id"
    }
```

#### Expected response:

```json
    {
        "result": "0x00000000000000000000000000000001"
    }
```


### 2. Verifying an unknown email:

```json
    {
        "email": "notfound@starknet.id"
    }
```

#### Expected response:

```json
    {
        "result": "0x00000000000000000000000000000000"
    }
```

closes #21 