### PR TITLE
feat: add get_metahash endpoint

### DIFF
--- a/src/endpoints/renewal/get_metahash.rs
+++ b/src/endpoints/renewal/get_metahash.rs
@@ -8,38 +8,36 @@ use axum::{
     response::{IntoResponse, Json},
 };
 use futures::StreamExt;
-use mongodb::bson::doc;
+use mongodb::bson::{doc, Bson};
 use serde::{Deserialize, Serialize};
 use starknet::core::types::FieldElement;
 use std::sync::Arc;
 
 #[derive(Serialize)]
-pub struct StarknetIdData {
-    starknet_id: String,
+pub struct GetMetaHashData {
+    meta_hash: String,
 }
 
 #[derive(Deserialize)]
-pub struct StarknetIdQuery {
+pub struct GetMetaHashQuery {
     addr: FieldElement,
-    domain: String,
 }
 
 pub async fn handler(
     State(state): State<Arc<AppState>>,
-    Query(query): Query<StarknetIdQuery>,
+    Query(query): Query<GetMetaHashQuery>,
 ) -> impl IntoResponse {
     let renew_collection = state
-        .starknetid_db
-        .collection::<mongodb::bson::Document>("auto_renew_flows");
+        .sales_db
+        .collection::<mongodb::bson::Document>("sales");
 
     let documents = renew_collection
         .find(
             doc! {
-                "renewer_address": to_hex(&query.addr),
-                "domain": query.domain,
+                "payer": to_hex(&query.addr),
                 "$or": [
                     { "_cursor.to": { "$exists": false } },
-                    { "_cursor.to": null },
+                    { "_cursor.to": Bson::Null },
                 ],
             },
             None,
@@ -54,15 +52,23 @@ pub async fn handler(
             if let Some(result) = cursor.next().await {
                 match result {
                     Ok(res) => {
-                        let mut res = res;
-                        res.remove("_id");
-                        res.remove("_cursor");
+                        let meta_hash_str = res.get_str("meta_hash").unwrap();
+                        let res = GetMetaHashData {
+                            meta_hash: meta_hash_str.to_string(),
+                        };
                         (StatusCode::OK, headers, Json(res)).into_response()
                     }
                     Err(e) => get_error(format!("Error while processing the document: {:?}", e)),
                 }
             } else {
-                get_error("no results founds".to_string())
+                (
+                    StatusCode::OK,
+                    headers,
+                    Json(GetMetaHashData {
+                        meta_hash: "".to_string(),
+                    }),
+                )
+                    .into_response()
             }
         }
         Err(_) => get_error("Error while fetching from database".to_string()),

--- a/src/endpoints/renewal/mod.rs
+++ b/src/endpoints/renewal/mod.rs
@@ -1,1 +1,2 @@
+pub mod get_metahash;
 pub mod get_renewal_data;

--- a/src/endpoints/stats/count_addrs.rs
+++ b/src/endpoints/stats/count_addrs.rs
@@ -6,7 +6,7 @@ use axum::{
     Json,
 };
 use futures::StreamExt;
-use mongodb::bson::doc;
+use mongodb::bson::{doc, Bson};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
@@ -33,7 +33,13 @@ pub async fn handler(
     let aggregate_cursor = domain_collection
         .aggregate(
             vec![
-                doc! { "$match": { "_cursor.to": null, "creation_date": { "$gte": query.since } }},
+                doc! { "$match": {
+                    "creation_date": { "$gte": query.since },
+                    "$or": [
+                        { "_cursor.to": { "$exists": false } },
+                        { "_cursor.to": Bson::Null },
+                    ],
+                }},
                 doc! { "$group": { "_id": "$legacy_address" }},
                 doc! { "$count": "total" },
             ],

--- a/src/endpoints/stats/count_club_domains.rs
+++ b/src/endpoints/stats/count_club_domains.rs
@@ -6,7 +6,7 @@ use axum::{
     Json,
 };
 use futures::TryStreamExt;
-use mongodb::bson::{self, doc};
+use mongodb::bson::{self, doc, Bson};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use std::collections::HashMap;
@@ -39,7 +39,10 @@ pub async fn handler(
             vec![
                 doc! {
                     "$match": {
-                        "_cursor.to": null,
+                        "$or": [
+                            { "_cursor.to": { "$exists": false } },
+                            { "_cursor.to": Bson::Null },
+                        ],
                         // todo: uncomment when there is a creation_date in the collection custom_resolutions
                         // "creation_date": {
                         //     "$gte": query.since,
@@ -89,10 +92,13 @@ pub async fn handler(
     let db_output = domain_collection.aggregate(vec![
             doc! {
                 "$match": {
-                    "_cursor.to": null,
                     "creation_date": {
                         "$gte": query.since,
-                    }
+                    },
+                    "$or": [
+                        { "_cursor.to": { "$exists": false } },
+                        { "_cursor.to": Bson::Null },
+                    ],
                 }
             },
             doc! {

--- a/src/endpoints/stats/count_created.rs
+++ b/src/endpoints/stats/count_created.rs
@@ -6,7 +6,7 @@ use axum::{
     Json,
 };
 use futures::StreamExt;
-use mongodb::bson::doc;
+use mongodb::bson::{doc, Bson};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
@@ -35,12 +35,17 @@ pub async fn handler(
         let mut headers = HeaderMap::new();
         headers.insert("Cache-Control", HeaderValue::from_static("max-age=60"));
 
-        let domain_collection = state.starknetid_db.collection::<mongodb::bson::Document>("domains");
+        let domain_collection = state
+            .starknetid_db
+            .collection::<mongodb::bson::Document>("domains");
 
         let pipeline = vec![
             doc! {
                 "$match": {
-                    "_cursor.to": null,
+                    "$or": [
+                        { "_cursor.to": { "$exists": false } },
+                        { "_cursor.to": Bson::Null },
+                    ],
                     "creation_date": {
                         "$gte": begin_time,
                         "$lte": end_time

--- a/src/endpoints/stats/count_ids.rs
+++ b/src/endpoints/stats/count_ids.rs
@@ -5,7 +5,7 @@ use axum::{
     response::IntoResponse,
     Json,
 };
-use mongodb::bson::doc;
+use mongodb::bson::{doc, Bson};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
@@ -32,7 +32,10 @@ pub async fn handler(
     let filter = doc! {
         "expiry": { "$gte": chrono::Utc::now().timestamp() },
         "creation_date": { "$gte": query.since },
-        "_cursor.to": { "$eq": null },
+        "$or": [
+            { "_cursor.to": { "$exists": false } },
+            { "_cursor.to": Bson::Null },
+        ],
     };
 
     let total = domain_collection.count_documents(filter, None).await;

--- a/src/endpoints/stats/count_renewed.rs
+++ b/src/endpoints/stats/count_renewed.rs
@@ -1,0 +1,109 @@
+use crate::{models::AppState, utils::get_error};
+use axum::{
+    extract::{Query, State},
+    http::{HeaderMap, HeaderValue, StatusCode},
+    response::IntoResponse,
+    Json,
+};
+use futures::StreamExt;
+use mongodb::bson::{doc, Bson};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+#[derive(Serialize)]
+pub struct CountRenewedData {
+    from: i64,
+    count: i32,
+}
+
+#[derive(Deserialize)]
+pub struct CountRenewedQuery {
+    begin: i64,
+    end: i64,
+    segments: i64,
+}
+
+pub async fn handler(
+    State(state): State<Arc<AppState>>,
+    Query(query): Query<CountRenewedQuery>,
+) -> impl IntoResponse {
+    let begin_time = query.begin;
+    let end_time = query.end;
+    let delta_time = ((end_time as f64 - begin_time as f64) / query.segments as f64).round() as i64;
+
+    if delta_time > 3600 {
+        let mut headers = HeaderMap::new();
+        headers.insert("Cache-Control", HeaderValue::from_static("max-age=60"));
+
+        let domain_collection = state
+            .starknetid_db
+            .collection::<mongodb::bson::Document>("renewals");
+
+        let pipeline = vec![
+            doc! {
+                "$match": {
+                    "$or": [
+                        { "_cursor.to": { "$exists": false } },
+                        { "_cursor.to": Bson::Null },
+                    ],
+                    "timestamp": {
+                        "$gte": begin_time,
+                        "$lte": end_time
+                    }
+                }
+            },
+            doc! {
+                "$group": {
+                    "_id": {
+                        "$floor": {
+                            "$sum": [
+                                {
+                                    "$subtract": [
+                                        {
+                                            "$subtract": ["$timestamp", begin_time]
+                                        },
+                                        {
+                                            "$mod": [
+                                                {
+                                                    "$subtract": ["$timestamp", begin_time]
+                                                },
+                                                delta_time
+                                            ]
+                                        }
+                                    ]
+                                },
+                                begin_time
+                            ]
+                        }
+                    },
+                    "count": {
+                        "$sum": 1
+                    }
+                }
+            },
+            doc! {
+                "$project": {
+                    "_id": 0,
+                    "from": "$_id",
+                    "count": "$count"
+                }
+            },
+        ];
+
+        let cursor = domain_collection.aggregate(pipeline, None).await.unwrap();
+        let result: Vec<CountRenewedData> = cursor
+            .map(|doc| {
+                let doc = doc.unwrap();
+                let from: i64 = doc.get_i64("from").unwrap();
+                let count = doc.get_i32("count").unwrap();
+
+                CountRenewedData { from, count }
+            })
+            .collect::<Vec<_>>()
+            .await;
+
+        (StatusCode::OK, headers, Json(result)).into_response()
+    } else {
+        get_error("delta must be greater than 3600 seconds".to_string())
+    }
+}

--- a/src/endpoints/stats/expired_club_domains.rs
+++ b/src/endpoints/stats/expired_club_domains.rs
@@ -6,7 +6,10 @@ use axum::{
     Json,
 };
 use futures::StreamExt;
-use mongodb::{bson::doc, options::AggregateOptions};
+use mongodb::{
+    bson::{doc, Bson},
+    options::AggregateOptions,
+};
 use serde::Serialize;
 use std::sync::Arc;
 
@@ -28,7 +31,10 @@ pub async fn handler(State(state): State<Arc<AppState>>) -> impl IntoResponse {
     let pipeline = vec![
         doc! {
             "$match": {
-                "_cursor.to": null,
+                "$or": [
+                    { "_cursor.to": { "$exists": false } },
+                    { "_cursor.to": Bson::Null },
+                ],
                 "expiry": {
                     "$lte": current,
                 }

--- a/src/endpoints/stats/mod.rs
+++ b/src/endpoints/stats/mod.rs
@@ -3,4 +3,5 @@ pub mod count_club_domains;
 pub mod count_created;
 pub mod count_domains;
 pub mod count_ids;
+pub mod count_renewed;
 pub mod expired_club_domains;

--- a/src/main.rs
+++ b/src/main.rs
@@ -119,6 +119,10 @@ async fn main() {
             get(endpoints::stats::expired_club_domains::handler),
         )
         .route(
+            "/stats/count_renewed",
+            get(endpoints::stats::count_renewed::handler),
+        )
+        .route(
             "/starkscan/fetch_nfts",
             get(endpoints::starkscan::fetch_nfts::handler),
         )

--- a/src/main.rs
+++ b/src/main.rs
@@ -126,6 +126,10 @@ async fn main() {
             "/renewal/get_renewal_data",
             get(endpoints::renewal::get_renewal_data::handler),
         )
+        .route(
+            "/renewal/get_metahash",
+            get(endpoints::renewal::get_metahash::handler),
+        )
         .route("/galxe/verify", post(endpoints::galxe::verify::handler))
         .with_state(shared_state)
         .layer(cors);


### PR DESCRIPTION
This PR: 
- adds a new `renewal/get_metahash` endpoint that will be used in the frontend for the autorenewal, to avoid asking twice email & sales tax to users that have already answered. 
- updates the stats endpoint to ensure that results with `_cursor.to` that doesn't exists are also returned
- adds missing endpoint for stats `count_renewed`

close https://github.com/starknet-id/api.starknet.id/issues/12
close https://github.com/starknet-id/stats.starknet.id/issues/28