### PR TITLE
feat: add support for multiple verifiers, use the most recent

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -28,7 +28,7 @@ pub_struct!(Clone, Deserialize; Database {
 pub_struct!(Clone, Deserialize; Contracts {
     starknetid: FieldElement,
     naming: FieldElement,
-    verifier: FieldElement,
+    verifiers: Vec<FieldElement>,
     old_verifier: FieldElement,
     pop_verifier: FieldElement,
 });


### PR DESCRIPTION
This pull request adds support for multiple social verifiers, when multiple values are conflicting, it will take the most recent one. This allows us to update the social verifier to a new implementation (hopefully upgradable this one) without needing users to reverify.

I added a sort in the aggregate to get results from the oldest to the new one and the algorithm will loop around them and override the values until the end.