### PR TITLE
fix: replace next_url by cursor in fetch_nfts endpoint

### DIFF
--- a/src/endpoints/starkscan/fetch_nfts.rs
+++ b/src/endpoints/starkscan/fetch_nfts.rs
@@ -67,10 +67,7 @@ pub async fn handler(
     {
         Ok(response) => match response.text().await {
             Ok(text) => match serde_json::from_str::<StarkscanApiResult>(&text) {
-                Ok(res) => {
-                    println!("Got response: {:?}", res);
-                    (StatusCode::OK, Json(res)).into_response()
-                }
+                Ok(res) => (StatusCode::OK, Json(res)).into_response(),
                 Err(e) => get_error(format!(
                     "Failed to deserialize result from Starkscan API: {} for response: {}",
                     e, text


### PR DESCRIPTION
This PR fixes the `fetch_nfts` endpoint. The `next_url` received from starkscan for users that have more than 30 nfts is actually a full url, I replaced it with the `cursor` that we'll received in `next_url`.