### PR TITLE
Wip/pfp

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,5 @@ toml = "0.7.4"
 tower-http = { version = "0.4.0", features = ["cors"] }
 chrono = "0.4.24"
 reqwest = "0.11.20"
+ark-ff = "0.4.2"
+hex = "0.4.3"

--- a/config.template.toml
+++ b/config.template.toml
@@ -18,7 +18,7 @@ pop_verifier = "0xXXXXXXXXXXXX"
 pp_verifier = "0xXXXXXXXXXXXX"
 
 [starkscan]
-api_url = "https://api-testnet.starkscan.co/api/v0/"
+api_url = "https://api-testnet.starkscan.co/api/v0"
 api_key = "xxxxxx"
 
 [custom_resolvers]

--- a/config.template.toml
+++ b/config.template.toml
@@ -15,6 +15,7 @@ naming = "0xXXXXXXXXXXXX"
 verifier = "0xXXXXXXXXXXXX"
 old_verifier = "0xXXXXXXXXXXXX"
 pop_verifier = "0xXXXXXXXXXXXX"
+pp_verifier = "0xXXXXXXXXXXXX"
 
 [starkscan]
 api_url = "https://api-testnet.starkscan.co/api/v0/"

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,6 +31,7 @@ pub_struct!(Clone, Deserialize; Contracts {
     verifiers: Vec<FieldElement>,
     old_verifier: FieldElement,
     pop_verifier: FieldElement,
+    pp_verifier: FieldElement,
 });
 
 pub_struct!(Clone, Deserialize; Starkscan {

--- a/src/endpoints/addr_to_full_ids.rs
+++ b/src/endpoints/addr_to_full_ids.rs
@@ -24,6 +24,14 @@ pub struct FullId {
     domain: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     domain_expiry: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    nft_pp: Option<NFTPP>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct NFTPP {
+    contract: String,
+    id: String,
 }
 
 #[derive(Deserialize)]
@@ -40,41 +48,91 @@ pub async fn handler(
     State(state): State<Arc<AppState>>,
     Query(query): Query<AddrQuery>,
 ) -> impl IntoResponse {
-    let id_owners = state.starknetid_db.collection::<mongodb::bson::Document>("id_owners");
+    let id_owners = state
+        .starknetid_db
+        .collection::<mongodb::bson::Document>("id_owners");
 
-    let pipeline = vec![
+    let pipeline = [
         doc! {
-            "$match": {
-                "owner": to_hex(&query.addr),
+            "$addFields": doc! {
+                "id": to_hex(&query.addr),
                 "_cursor.to": Bson::Null
-            },
+            }
         },
         doc! {
-            "$lookup": {
+            "$lookup": doc! {
                 "from": "domains",
-                "let": { "local_id": "$id" },
+                "let": doc! {
+                    "local_id": "$id"
+                },
                 "pipeline": [
-                    { "$match": {
-                        "$expr": { "$eq": [ "$id", "$$local_id" ] },
-                        "_cursor.to": Bson::Null
-                    }}
+                    doc! {
+                        "$match": doc! {
+                            "$expr": doc! {
+                                "$eq": [
+                                    "$id",
+                                    "$$local_id"
+                                ]
+                            },
+                            "_cursor.to": Bson::Null
+                        }
+                    }
                 ],
-                "as": "domainData",
-            },
+                "as": "domainData"
+            }
         },
         doc! {
-            "$unwind": {
+            "$unwind": doc! {
                 "path": "$domainData",
-                "preserveNullAndEmptyArrays": true,
-            },
+                "preserveNullAndEmptyArrays": true
+            }
         },
         doc! {
-            "$project": {
+            "$lookup": doc! {
+                "from": "id_verifier_data",
+                "let": doc! {
+                    "local_id": "$id"
+                },
+                "pipeline": [
+                    doc! {
+                        "$match": doc! {
+                            "$expr": doc! {
+                                "$eq": [
+                                    "$id",
+                                    "$$local_id"
+                                ]
+                            },
+                            "field": doc! {
+                                "$in": [
+                                    // nft_pp_contract
+                                    "0x00000000000000000000000000000000006e66745f70705f636f6e7472616374",
+                                    // nft_pp_id
+                                    "0x0000000000000000000000000000000000000000000000000074776974746572"
+                                ]
+                            },
+                            "verifier": to_hex(&state.conf.contracts.pp_verifier),
+                            "_cursor.to": Bson::Null
+                        }
+                    },
+                    doc! {
+                        "$project": doc! {
+                            "_id": 0,
+                            "field": 1,
+                            "data": 1
+                        }
+                    }
+                ],
+                "as": "verifierData"
+            }
+        },
+        doc! {
+            "$project": doc! {
                 "_id": 0,
                 "id": 1,
                 "domain": "$domainData.domain",
                 "domain_expiry": "$domainData.expiry",
-            },
+                "pp_verifier_data": "$verifierData"
+            }
         },
     ];
 
@@ -93,10 +151,32 @@ pub async fn handler(
                     .to_string();
                     let domain = doc.get_str("domain").ok().map(String::from);
                     let domain_expiry = doc.get_i32("domain_expiry").ok();
+                    let pp_verifier_data = doc.get_array("pp_verifier_data").ok();
+                    let mut nft_pp = None;
+                    if let Some(data) = pp_verifier_data {
+                        if data.len() >= 2 {
+                            if let (Some(contract_data), Some(id_data)) = (data.get(0), data.get(1))
+                            {
+                                if let (Bson::Document(contract_doc), Bson::Document(id_doc)) =
+                                    (contract_data, id_data)
+                                {
+                                    if let (Ok(contract_str), Ok(id_str)) =
+                                        (contract_doc.get_str("data"), id_doc.get_str("data"))
+                                    {
+                                        nft_pp = Some(NFTPP {
+                                            contract: contract_str.to_string(),
+                                            id: id_str.to_string(),
+                                        });
+                                    }
+                                }
+                            }
+                        }
+                    }
                     full_ids.push(FullId {
                         id,
                         domain,
                         domain_expiry,
+                        nft_pp,
                     });
                 }
             }

--- a/src/endpoints/id_to_data.rs
+++ b/src/endpoints/id_to_data.rs
@@ -1,7 +1,7 @@
 use crate::{
     models::{AppState, Data},
     resolving::get_custom_resolver,
-    utils::{get_error, to_hex},
+    utils::{fetch_img_url, get_error, to_hex, to_u256},
 };
 use axum::{
     extract::{Query, State},
@@ -12,12 +12,23 @@ use futures::StreamExt;
 use mongodb::bson::{doc, Bson, Document};
 use serde::Deserialize;
 use starknet::core::types::FieldElement;
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 #[derive(Deserialize)]
 pub struct IdQuery {
     id: FieldElement,
 }
+
+#[derive(Debug)]
+pub struct VerifierData {
+    data: Option<String>,
+    extended_data: Option<Vec<String>>,
+}
+
+const NFT_PP_CONTRACT: &'static str =
+    "0x00000000000000000000000000000000006e66745f70705f636f6e7472616374";
+const NFT_PP_ID: &'static str =
+    "0x00000000000000000000000000000000000000000000006e66745f70705f6964";
 
 pub async fn handler(
     State(state): State<Arc<AppState>>,
@@ -107,7 +118,14 @@ pub async fn handler(
                     {
                         "field": "0x0000000000000000000000000070726f6f665f6f665f706572736f6e686f6f64",
                         "verifier": to_hex(&state.conf.contracts.pop_verifier)
-                    }
+                    },
+                    {
+                        "field": {
+                            // nft_pp_contract, nft_pp_id
+                            "$in": ["0x00000000000000000000000000000000006e66745f70705f636f6e7472616374", "0x00000000000000000000000000000000000000000000006e66745f70705f6964", "0x00000000000000000000000000000000000000000000000000646973636f7264"]
+                        },
+                        "verifier": to_hex(&state.conf.contracts.pp_verifier)
+                    },
                 ],
                 "id": &hex_id,
                 "_cursor.to": null,
@@ -121,7 +139,8 @@ pub async fn handler(
         doc! {
             "$group": {
                 "_id": { "field": "$field", "verifier": "$verifier" }, // group by both field and verifier
-                "data": { "$first": "$data" }
+                "data": { "$first": "$data" },
+                "extended_data": { "$first": "$extended_data" }
             }
         },
     ];
@@ -131,107 +150,161 @@ pub async fn handler(
         .collection::<Document>("id_verifier_data");
     let results = starknet_ids_data.aggregate(pipeline, None).await;
 
-    let mut github = None;
-    let mut twitter = None;
-    let mut discord = None;
-    let mut proof_of_personhood = None;
-    let mut old_github = None;
-    let mut old_twitter = None;
-    let mut old_discord = None;
-
+    let mut verifier_data_by_field: HashMap<(String, String), VerifierData> = HashMap::new();
     if let Ok(mut cursor) = results {
         while let Some(result) = cursor.next().await {
             if let Ok(doc) = result {
-                let field = doc
-                    .get_document("_id")
-                    .unwrap()
-                    .get_str("field")
-                    .unwrap_or_default();
-                let verifier = doc
-                    .get_document("_id")
-                    .unwrap()
-                    .get_str("verifier")
-                    .unwrap_or_default();
-
-                // it's a bit ugly but it will get better when we removed the old verifier
-                match (field, verifier) {
-                    (
-                        "0x0000000000000000000000000000000000000000000000000000676974687562",
-                        verifier,
-                    ) if current_social_verifiers.contains(&verifier.to_string()) => {
-                        github = doc.get_str("data").ok().and_then(|data| {
-                            FieldElement::from_hex_be(data)
-                                .map(|fe| fe.to_string())
+                match doc.get_document("_id") {
+                    Ok(inner_doc) => {
+                        if let (Ok(verifier), Ok(field)) =
+                            (inner_doc.get_str("verifier"), inner_doc.get_str("field"))
+                        {
+                            let data = doc.get_str("data").ok().map(String::from);
+                            let extended_data = doc
+                                .get_array("extended_data")
                                 .ok()
-                        })
+                                .map(|bson_array| {
+                                    bson_array
+                                        .iter()
+                                        .filter_map(|bson| bson.as_str().map(String::from))
+                                        .collect()
+                                })
+                                .filter(|v: &Vec<String>| !v.is_empty());
+                            verifier_data_by_field.insert(
+                                (verifier.to_string(), field.to_string()),
+                                VerifierData {
+                                    data,
+                                    extended_data,
+                                },
+                            );
+                        }
                     }
-                    (
-                        "0x0000000000000000000000000000000000000000000000000000676974687562",
-                        verifier,
-                    ) if verifier == to_hex(&state.conf.contracts.old_verifier) => {
-                        old_github = doc.get_str("data").ok().and_then(|data| {
-                            FieldElement::from_hex_be(data)
-                                .map(|fe| fe.to_string())
-                                .ok()
-                        })
-                    }
-
-                    (
-                        "0x0000000000000000000000000000000000000000000000000074776974746572",
-                        verifier,
-                    ) if current_social_verifiers.contains(&verifier.to_string()) => {
-                        twitter = doc.get_str("data").ok().and_then(|data| {
-                            FieldElement::from_hex_be(data)
-                                .map(|fe| fe.to_string())
-                                .ok()
-                        })
-                    }
-                    (
-                        "0x0000000000000000000000000000000000000000000000000074776974746572",
-                        verifier,
-                    ) if verifier == to_hex(&state.conf.contracts.old_verifier) => {
-                        old_twitter = doc.get_str("data").ok().and_then(|data| {
-                            FieldElement::from_hex_be(data)
-                                .map(|fe| fe.to_string())
-                                .ok()
-                        })
-                    }
-
-                    (
-                        "0x00000000000000000000000000000000000000000000000000646973636f7264",
-                        verifier,
-                    ) if current_social_verifiers.contains(&verifier.to_string()) => {
-                        discord = doc.get_str("data").ok().and_then(|data| {
-                            FieldElement::from_hex_be(data)
-                                .map(|fe| fe.to_string())
-                                .ok()
-                        })
-                    }
-                    (
-                        "0x00000000000000000000000000000000000000000000000000646973636f7264",
-                        verifier,
-                    ) if verifier == to_hex(&state.conf.contracts.old_verifier) => {
-                        old_discord = doc.get_str("data").ok().and_then(|data| {
-                            FieldElement::from_hex_be(data)
-                                .map(|fe| fe.to_string())
-                                .ok()
-                        })
-                    }
-
-                    ("0x0000000000000000000000000070726f6f665f6f665f706572736f6e686f6f64", _)
-                        if verifier == to_hex(&state.conf.contracts.pop_verifier) =>
-                    {
-                        // ensure pop is valid
-                        proof_of_personhood = doc.get_str("data").ok()
-                        .and_then(| data |
-                             Some(data == "0x0000000000000000000000000000000000000000000000000000000000000001"));
-                    }
-
-                    _ => {}
+                    Err(_) => {}
                 }
             }
         }
     }
+
+    let mut github = None;
+    for verifier in current_social_verifiers.to_owned() {
+        match verifier_data_by_field.get(&(
+            verifier,
+            "0x0000000000000000000000000000000000000000000000000000676974687562".to_string(),
+        )) {
+            Some(verifier_data) => {
+                github = verifier_data.data.to_owned().and_then(|data| {
+                    FieldElement::from_hex_be(&data)
+                        .map(|fe| fe.to_string())
+                        .ok()
+                });
+            }
+            None => {}
+        }
+    }
+
+    let old_github = match verifier_data_by_field.get(&(
+        to_hex(&state.conf.contracts.old_verifier),
+        "0x0000000000000000000000000000000000000000000000000000676974687562".to_string(),
+    )) {
+        Some(verifier_data) => verifier_data.data.to_owned().and_then(|data| {
+            FieldElement::from_hex_be(&data)
+                .map(|fe| fe.to_string())
+                .ok()
+        }),
+        None => None,
+    };
+
+    let mut twitter = None;
+    for verifier in current_social_verifiers.to_owned() {
+        match verifier_data_by_field.get(&(
+            verifier,
+            "0x0000000000000000000000000000000000000000000000000074776974746572".to_string(),
+        )) {
+            Some(verifier_data) => {
+                twitter = verifier_data.data.to_owned().and_then(|data| {
+                    FieldElement::from_hex_be(&data)
+                        .map(|fe| fe.to_string())
+                        .ok()
+                })
+            }
+            None => {}
+        }
+    }
+
+    let old_twitter = match verifier_data_by_field.get(&(
+        to_hex(&state.conf.contracts.old_verifier),
+        "0x0000000000000000000000000000000000000000000000000074776974746572".to_string(),
+    )) {
+        Some(verifier_data) => verifier_data.data.to_owned().and_then(|data| {
+            FieldElement::from_hex_be(&data)
+                .map(|fe| fe.to_string())
+                .ok()
+        }),
+        None => None,
+    };
+
+    let mut discord: Option<String> = None;
+    for verifier in current_social_verifiers.to_owned() {
+        match verifier_data_by_field.get(&(
+            verifier,
+            "0x00000000000000000000000000000000000000000000000000646973636f7264".to_string(),
+        )) {
+            Some(verifier_data) => {
+                discord = verifier_data.data.to_owned().and_then(|data| {
+                    FieldElement::from_hex_be(&data)
+                        .map(|fe| fe.to_string())
+                        .ok()
+                })
+            }
+            None => {}
+        }
+    }
+
+    let old_discord = match verifier_data_by_field.get(&(
+        to_hex(&state.conf.contracts.old_verifier),
+        "0x00000000000000000000000000000000000000000000000000646973636f7264".to_string(),
+    )) {
+        Some(verifier_data) => verifier_data.data.to_owned().and_then(|data| {
+            FieldElement::from_hex_be(&data)
+                .map(|fe| fe.to_string())
+                .ok()
+        }),
+        None => None,
+    };
+
+    let proof_of_personhood = match verifier_data_by_field.get(&(
+        to_hex(&state.conf.contracts.pop_verifier),
+        "0x0000000000000000000000000070726f6f665f6f665f706572736f6e686f6f64".to_string(),
+    )) {
+        Some(verifier_data) => verifier_data.data.to_owned().and_then(|data| {
+            Some(data == "0x0000000000000000000000000000000000000000000000000000000000000001")
+        }),
+        None => None,
+    };
+
+    let img_url = match (
+        verifier_data_by_field.get(&(
+            to_hex(&state.conf.contracts.pp_verifier),
+            NFT_PP_CONTRACT.to_string(),
+        )),
+        verifier_data_by_field.get(&(
+            to_hex(&state.conf.contracts.pp_verifier),
+            NFT_PP_ID.to_string(),
+        )),
+    ) {
+        (Option::Some(data_contract), Option::Some(data_id)) => {
+            let id_felts = data_id.to_owned().extended_data.as_ref().unwrap();
+            let id = to_u256(id_felts.get(0).unwrap(), id_felts.get(1).unwrap());
+            fetch_img_url(
+                &state.conf.starkscan.api_url,
+                &state.conf.starkscan.api_key,
+                data_contract.data.to_owned().unwrap(),
+                id.to_string(),
+            )
+            .await
+        }
+        _ => None,
+    };
 
     let data = match domain_data {
         None => Data {
@@ -248,6 +321,7 @@ pub async fn handler(
             old_twitter,
             old_discord,
             starknet_id: query.id.to_string(),
+            img_url,
         },
         Some((domain, addr, expiry)) => {
             let is_owner_main_document = domains
@@ -277,6 +351,7 @@ pub async fn handler(
                 old_twitter,
                 old_discord,
                 starknet_id: query.id.to_string(),
+                img_url,
             }
         }
     };

--- a/src/endpoints/starkscan/fetch_nfts.rs
+++ b/src/endpoints/starkscan/fetch_nfts.rs
@@ -49,7 +49,7 @@ pub async fn handler(
     Query(query): Query<FetchNftsQuery>,
 ) -> impl IntoResponse {
     let base_url = format!(
-        "{}nfts?owner_address={}",
+        "{}/nfts?owner_address={}",
         state.conf.starkscan.api_url,
         to_hex(&query.addr)
     );

--- a/src/endpoints/uri.rs
+++ b/src/endpoints/uri.rs
@@ -1,15 +1,11 @@
-use crate::{
-    models::AppState,
-    utils::{get_error, to_hex},
-};
+use crate::{models::AppState, utils::to_hex};
 use axum::{
     extract::{Query, State},
     http::{HeaderMap, HeaderValue, StatusCode},
     response::{IntoResponse, Json},
 };
 use chrono::NaiveDateTime;
-use futures::StreamExt;
-use mongodb::{bson::doc, options::AggregateOptions};
+use mongodb::bson::doc;
 use serde::{Deserialize, Serialize};
 use starknet::core::types::FieldElement;
 use std::sync::Arc;
@@ -47,99 +43,80 @@ pub async fn handler(
     let domains = state
         .starknetid_db
         .collection::<mongodb::bson::Document>("domains");
+    let id_verifier_data = state
+        .starknetid_db
+        .collection::<mongodb::bson::Document>("id_verifier_data");
 
-    let aggregation_pipeline = vec![
-        doc! {
-            "$match": {
-                "id": to_hex(&query.id),
-                "_cursor.to": null,
-            }
-        },
-        doc! {
-            "$lookup": {
-                "from": "id_verifier_data",
-                "let": { "token_id": "$id" },
-                "pipeline": [
-                    {
-                        "$match": {
-                            "$expr": {
-                                "$eq": ["$id", "$$token_id"]
-                            },
-                            "$or": [
-                                { "_cursor.to": null },
-                                { "_cursor.to": { "$exists": false } }
-                            ],
-                            "verifier" : "0x070378cc131622ed8099a1e47adcd0c76341c206dea05917a8dcb6896b0c6601",
-                            "field": "0x00000000000000000000000000000000006e66745f70705f636f6e7472616374",
-                        }
-                    }
-                ],
-                "as": "verifier_info"
-            }
-        },
-    ];
+    // Query the domains collection
+    let domain_filter = doc! {
+        "id": to_hex(&query.id),
+        "_cursor.to": null
+    };
+    let domain_data = domains.find_one(domain_filter, None).await.unwrap();
 
-    let options = AggregateOptions::default();
-    let mut cursor = domains
-        .aggregate(aggregation_pipeline, options)
-        .await
-        .unwrap();
+    // Query the id_verifier_data collection
+    let verifier_filter = doc! {
+        "id": to_hex(&query.id),
+        "$or": [
+            { "_cursor.to": null },
+            { "_cursor.to": { "$exists": false } }
+        ],
+        "verifier" : "0x070378cc131622ed8099a1e47adcd0c76341c206dea05917a8dcb6896b0c6601",
+        "field": "0x00000000000000000000000000000000006e66745f70705f636f6e7472616374",
+    };
+
+    let verifier_data: Option<VerifierData> =
+        match id_verifier_data.find_one(verifier_filter, None).await {
+            Ok(Some(vi)) => {
+                let verifier = vi.get_str("verifier").unwrap_or_default().to_string();
+                let field = vi.get_str("field").unwrap_or_default().to_string();
+                Some(VerifierData { verifier, field })
+            }
+            _ => None,
+        };
+    println!("verifier_data; {:?}", verifier_data);
 
     let mut headers = HeaderMap::new();
     headers.insert("Cache-Control", HeaderValue::from_static("max-age=30"));
 
-    if let Some(result) = cursor.next().await {
-        match result {
-            Ok(doc) => {
-                let domain = doc.get_str("domain").unwrap_or_default().to_owned();
-                let expiry = doc.get_i64("expiry").unwrap_or_default();
-                let verifier_data: Option<VerifierData> = doc
-                    .get_array("verifier_info")
-                    .ok()
-                    .and_then(|array| array.get(0))
-                    .and_then(|first_entry| first_entry.as_document())
-                    .map(|vi| {
-                        let verifier = vi.get_str("verifier").unwrap_or_default().to_string();
-                        let field = vi.get_str("field").unwrap_or_default().to_string();
-                        VerifierData { verifier, field }
-                    });
+    match domain_data {
+        Some(doc) => {
+            let domain = doc.get_str("domain").unwrap_or_default().to_owned();
+            let expiry = doc.get_i64("expiry").unwrap_or_default();
 
-                println!("verifier_data: {:?}", verifier_data);
-
-                let token_uri = TokenURI {
-                    name: domain.clone(),
-                    description: "This token represents an identity on StarkNet.".to_string(),
-                    image: format!("https://starknet.id/api/identicons/{}", &query.id),
-                    expiry: Some(expiry),
-                    attributes: Some(vec![
-                        Attribute {
-                            trait_type: "Subdomain".to_string(),
-                            value: vec![if domain.contains(".") { "yes" } else { "no" }.to_string()],
-                        },
-                        Attribute {
-                            trait_type: "Domain expiry".to_string(),
-                            value: vec![NaiveDateTime::from_timestamp_opt(expiry.into(), 0)
-                                .map(|dt| dt.format("%b %d, %Y").to_string())
-                                .unwrap_or_else(|| "Invalid date".into())],
-                        },
-                        Attribute {
-                            trait_type: "Domain expiry timestamp".to_string(),
-                            value: vec![expiry.to_string()],
-                        },
-                    ]),
-                };
-                (StatusCode::OK, headers, Json(token_uri)).into_response()
-            }
-            Err(_) => get_error("Error while fetching from database".to_string()),
+            let token_uri = TokenURI {
+                name: domain.clone(),
+                description: "This token represents an identity on StarkNet.".to_string(),
+                image: format!("https://starknet.id/api/identicons/{}", &query.id),
+                expiry: Some(expiry),
+                attributes: Some(vec![
+                    Attribute {
+                        trait_type: "Subdomain".to_string(),
+                        value: vec![if domain.contains(".") { "yes" } else { "no" }.to_string()],
+                    },
+                    Attribute {
+                        trait_type: "Domain expiry".to_string(),
+                        value: vec![NaiveDateTime::from_timestamp_opt(expiry.into(), 0)
+                            .map(|dt| dt.format("%b %d, %Y").to_string())
+                            .unwrap_or_else(|| "Invalid date".into())],
+                    },
+                    Attribute {
+                        trait_type: "Domain expiry timestamp".to_string(),
+                        value: vec![expiry.to_string()],
+                    },
+                ]),
+            };
+            (StatusCode::OK, headers, Json(token_uri)).into_response()
         }
-    } else {
-        let token_uri = TokenURI {
-            name: format!("Starknet ID: {}", &query.id),
-            description: "This token represents an identity on StarkNet.".to_string(),
-            image: format!("https://starknet.id/api/identicons/{}", &query.id),
-            expiry: None,
-            attributes: None,
-        };
-        (StatusCode::OK, headers, Json(token_uri)).into_response()
+        None => {
+            let token_uri = TokenURI {
+                name: format!("Starknet ID: {}", &query.id),
+                description: "This token represents an identity on StarkNet.".to_string(),
+                image: format!("https://starknet.id/api/identicons/{}", &query.id),
+                expiry: None,
+                attributes: None,
+            };
+            (StatusCode::OK, headers, Json(token_uri)).into_response()
+        }
     }
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -34,4 +34,5 @@ pub struct Data {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub proof_of_personhood: Option<bool>,
     pub starknet_id: String,
+    pub img_url: Option<String>
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,8 +1,10 @@
+use ark_ff::{biginteger::BigInteger256, BigInteger};
 use axum::{
     http::StatusCode,
     response::{IntoResponse, Response},
 };
 use serde::Serialize;
+use serde_json::Value;
 use starknet::core::types::FieldElement;
 use std::fmt::Write;
 
@@ -23,4 +25,52 @@ pub fn to_hex(felt: &FieldElement) -> String {
         write!(&mut result, "{:02x}", byte).unwrap();
     }
     result
+}
+
+pub fn to_u256(low: &str, high: &str) -> BigInteger256 {
+    fn from_byte_slice(bytes: &[u8]) -> Option<BigInteger256> {
+        if bytes.len() > 32 {
+            return None; // Ensure the byte slice isn't larger than expected
+        }
+
+        let mut bits = [false; 256];
+        for (ind_byte, byte) in bytes.iter().enumerate() {
+            for ind_bit in 0..8 {
+                bits[ind_byte * 8 + ind_bit] = (byte >> (7 - ind_bit)) & 1 == 1;
+            }
+        }
+
+        Some(BigInteger256::from_bits_be(&bits))
+    }
+
+    let mut output = from_byte_slice(&hex::decode(&(low)[2..]).unwrap()).unwrap();
+    let mut _high = from_byte_slice(&hex::decode(&(high)[2..]).unwrap()).unwrap();
+
+    _high.muln(128);
+    let _ = output.add_with_carry(&_high);
+    output
+}
+
+pub async fn fetch_img_url(
+    api_url: &str,
+    api_key: &str,
+    contract: String,
+    id: String,
+) -> Option<String> {
+    let url = format!("{}/nft/{}/{}", api_url, contract, id);
+
+    let response_text = reqwest::Client::new()
+        .get(&url)
+        .header("accept", "application/json")
+        .header("x-api-key", api_key)
+        .send()
+        .await
+        .ok()?
+        .text()
+        .await
+        .ok()?;
+
+    let json: Value = serde_json::from_str(&response_text).ok()?;
+    json.get("image_url")
+        .and_then(|v| v.as_str().map(ToString::to_string))
 }


### PR DESCRIPTION
This Pull Request Improves Profile Pics Support

## Custom Profile Pictures in Wallets
Users can now display custom profile pictures in their wallets by updating the StarkNet ID URI.

## Speed Optimization
- `addr_to_full_ids` adds support for profile pics. It does this in an efficient manner by parallelizing calls to the starkscan API, resulting in quicker load times.
- `id_to_data`  and `domain_to_data` adds profile pic support in the same fashion

Close #31 
