### PR TITLE
fix: update get_metahash endpoint to return sales tax rate

### DIFF
--- a/config.template.toml
+++ b/config.template.toml
@@ -6,7 +6,7 @@ port = 8080
 name = "starknetid"
 connection_string = "xxxxxx"
 [databases.sales]
-name = "sales"
+name = "goerli"
 connection_string = "xxxxxx"
 
 [contracts]

--- a/src/endpoints/renewal/get_metahash.rs
+++ b/src/endpoints/renewal/get_metahash.rs
@@ -7,10 +7,8 @@ use axum::{
     http::{HeaderMap, HeaderValue, StatusCode},
     response::{IntoResponse, Json},
 };
-use mongodb::{
-    bson::{doc, Bson},
-    options::FindOneOptions,
-};
+use futures::TryStreamExt;
+use mongodb::bson::{doc, Bson};
 use serde::{Deserialize, Serialize};
 use starknet::core::types::FieldElement;
 use std::sync::Arc;
@@ -18,6 +16,7 @@ use std::sync::Arc;
 #[derive(Serialize)]
 pub struct GetMetaHashData {
     meta_hash: String,
+    tax_rate: f32,
 }
 
 #[derive(Deserialize)]
@@ -29,43 +28,71 @@ pub async fn handler(
     State(state): State<Arc<AppState>>,
     Query(query): Query<GetMetaHashQuery>,
 ) -> impl IntoResponse {
-    let renew_collection = state
+    let sales_collection = state
         .sales_db
         .collection::<mongodb::bson::Document>("sales");
 
-    let find_options = FindOneOptions::builder()
-        .sort(doc! { "timestamp": -1 })
-        .build();
-    let document = renew_collection
-        .find_one(
-            doc! {
-                "payer": to_hex(&query.addr),
-                "$or": [
-                    { "_cursor.to": { "$exists": false } },
-                    { "_cursor.to": Bson::Null },
-                ],
-            },
-            find_options,
-        )
-        .await;
-
-    if let Ok(sales_doc) = document {
-        if let Some(doc) = sales_doc {
-            let mut headers = HeaderMap::new();
-            headers.insert("Cache-Control", HeaderValue::from_static("max-age=30"));
-            match doc.get_str("meta_hash") {
-                Ok(meta_hash_str) => {
-                    let res = GetMetaHashData {
-                        meta_hash: meta_hash_str.to_string(),
-                    };
-                    (StatusCode::OK, headers, Json(res)).into_response()
-                }
-                Err(e) => get_error(format!("No meta_hash found: {:?}", e)),
+    let pipeline = vec![
+        doc! {"$match": {
+            "payer": to_hex(&query.addr),
+            "$or": [
+                { "_cursor.to": { "$exists": false } },
+                { "_cursor.to": Bson::Null },
+            ],
+        }},
+        doc! {"$sort": {"timestamp": -1}}, // take the most recent entry
+        doc! {"$lookup": {
+            "from": "metadata",
+            "localField": "meta_hash",
+            "foreignField": "meta_hash",
+            "as": "metadata_info"
+        }},
+        doc! {"$unwind": {
+            "path": "$metadata_info",
+            "preserveNullAndEmptyArrays": true
+        }},
+        doc! {"$project": {
+            "meta_hash": 1,
+            "tax_state": {
+                "$ifNull": ["$metadata_info.tax_state", ""]
             }
-        } else {
-            get_error("No results found".to_string())
-        }
-    } else {
-        get_error("Error while fetching from database".to_string())
+        }},
+        doc! {"$limit": 1},
+    ];
+
+    let cursor = sales_collection.aggregate(pipeline, None).await;
+    match cursor {
+        Ok(cursor) => match cursor.try_collect::<Vec<mongodb::bson::Document>>().await {
+            Ok(documents) => {
+                if documents.is_empty() {
+                    return get_error("No documents found".to_string());
+                }
+
+                let mut headers = HeaderMap::new();
+                headers.insert("Cache-Control", HeaderValue::from_static("max-age=30"));
+
+                println!("docs: {:?}", documents);
+                for doc in documents {
+                    if let Ok(meta_hash) = doc.get_str("meta_hash") {
+                        let mut tax_rate = 0.0;
+                        if let Some(tax_state) = doc.get("tax_state").and_then(|ts| ts.as_str()) {
+                            if let Some(state_info) =
+                                state.states.states.get(&tax_state.to_string())
+                            {
+                                tax_rate = state_info.rate;
+                            }
+                        }
+                        let res = GetMetaHashData {
+                            meta_hash: meta_hash.to_string(),
+                            tax_rate,
+                        };
+                        return (StatusCode::OK, headers, Json(res)).into_response();
+                    }
+                }
+                get_error("No metahash found".to_string())
+            }
+            Err(_) => get_error("Error while fetching from database".to_string()),
+        },
+        Err(_) => get_error("Error while fetching from database".to_string()),
     }
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,12 +1,14 @@
 use mongodb::Database;
 
 use crate::config::Config;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 pub struct AppState {
     pub conf: Config,
     pub starknetid_db: Database,
     pub sales_db: Database,
+    pub states: States,
 }
 
 #[derive(Serialize)]
@@ -34,5 +36,17 @@ pub struct Data {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub proof_of_personhood: Option<bool>,
     pub starknet_id: String,
-    pub img_url: Option<String>
+    pub img_url: Option<String>,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct State {
+    pub rate: f32,
+    #[serde(rename = "type")]
+    pub type_: String,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct States {
+    pub states: HashMap<String, State>,
 }

--- a/src/tax/mod.rs
+++ b/src/tax/mod.rs
@@ -1,0 +1,1 @@
+pub mod sales_tax;

--- a/src/tax/sales_tax.json
+++ b/src/tax/sales_tax.json
@@ -1,0 +1,233 @@
+{
+    "states": {
+        "AL": {
+        "rate": 4,
+        "type": "vat"
+        },
+
+        "AR": {
+        "rate": 0.06,
+        "type": "vat"
+        },
+
+        "AZ": {
+        "rate": 0.066,
+        "type": "vat"
+        },
+
+        "CA": {
+        "rate": 0.0825,
+        "type": "vat"
+        },
+
+        "CO": {
+        "rate": 0.029,
+        "type": "vat"
+        },
+
+        "CT": {
+        "rate": 0.06,
+        "type": "vat"
+        },
+
+        "DC": {
+        "rate": 0.06,
+        "type": "vat"
+        },
+
+        "FL": {
+        "rate": 0.06,
+        "type": "vat"
+        },
+
+        "GA": {
+        "rate": 0.04,
+        "type": "vat"
+        },
+
+        "HI": {
+        "rate": 0.04,
+        "type": "vat"
+        },
+
+        "IA": {
+        "rate": 0.06,
+        "type": "vat"
+        },
+
+        "ID": {
+        "rate": 0.06,
+        "type": "vat"
+        },
+
+        "IL": {
+        "rate": 0.0625,
+        "type": "vat"
+        },
+
+        "IN": {
+        "rate": 0.07,
+        "type": "vat"
+        },
+
+        "KS": {
+        "rate": 0.063,
+        "type": "vat"
+        },
+
+        "KY": {
+        "rate": 0.06,
+        "type": "vat"
+        },
+
+        "LA": {
+        "rate": 0.04,
+        "type": "vat"
+        },
+
+        "MA": {
+        "rate": 0.0625,
+        "type": "vat"
+        },
+
+        "MD": {
+        "rate": 0.06,
+        "type": "vat"
+        },
+
+        "ME": {
+        "rate": 0.05,
+        "type": "vat"
+        },
+
+        "MI": {
+        "rate": 0.06,
+        "type": "vat"
+        },
+
+        "MN": {
+        "rate": 0.06875,
+        "type": "vat"
+        },
+
+        "MO": {
+        "rate": 0.04225,
+        "type": "vat"
+        },
+
+        "MS": {
+        "rate": 0.07,
+        "type": "vat"
+        },
+
+        "NC": {
+        "rate": 0.0575,
+        "type": "vat"
+        },
+
+        "ND": {
+        "rate": 0.05,
+        "type": "vat"
+        },
+
+        "NE": {
+        "rate": 0.055,
+        "type": "vat"
+        },
+
+        "NJ": {
+        "rate": 0.07,
+        "type": "vat"
+        },
+
+        "NM": {
+        "rate": 0.05,
+        "type": "vat"
+        },
+
+        "NV": {
+        "rate": 0.0685,
+        "type": "vat"
+        },
+
+        "NY": {
+        "rate": 0.04,
+        "type": "vat"
+        },
+
+        "OH": {
+        "rate": 0.055,
+        "type": "vat"
+        },
+
+        "OK": {
+        "rate": 0.045,
+        "type": "vat"
+        },
+
+        "PA": {
+        "rate": 0.06,
+        "type": "vat"
+        },
+
+        "RI": {
+        "rate": 0.07,
+        "type": "vat"
+        },
+
+        "SC": {
+        "rate": 0.06,
+        "type": "vat"
+        },
+
+        "SD": {
+        "rate": 0.04,
+        "type": "vat"
+        },
+
+        "TN": {
+        "rate": 0.07,
+        "type": "vat"
+        },
+
+        "TX": {
+        "rate": 0.0625,
+        "type": "vat"
+        },
+
+        "UT": {
+        "rate": 0.0595,
+        "type": "vat"
+        },
+
+        "VA": {
+        "rate": 0.05,
+        "type": "vat"
+        },
+
+        "VT": {
+        "rate": 0.06,
+        "type": "vat"
+        },
+
+        "WA": {
+        "rate": 0.065,
+        "type": "vat"
+        },
+
+        "WI": {
+        "rate": 0.05,
+        "type": "vat"
+        },
+
+        "WV": {
+        "rate": 0.06,
+        "type": "vat"
+        },
+
+        "WY": {
+        "rate": 0.04,
+        "type": "vat"
+        }
+    }
+}

--- a/src/tax/sales_tax.rs
+++ b/src/tax/sales_tax.rs
@@ -1,0 +1,22 @@
+use crate::models::States;
+use std::{collections::HashMap, fs};
+
+pub async fn load_sales_tax() -> States {
+    match fs::read_to_string("./src/tax/sales_tax.json") {
+        Ok(data) => match serde_json::from_str(&data) {
+            Ok(states) => states,
+            Err(e) => {
+                println!("Unable to parse sales tax file: {}", e);
+                States {
+                    states: HashMap::new(),
+                }
+            }
+        },
+        Err(e) => {
+            println!("Unable to load sales tax file: {}", e);
+            States {
+                states: HashMap::new(),
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR updates the get_metahash endpoint to return the sales tax rate as well so we can use it to set the right allowance in the auto renewal tx. 