### PR TITLE
fix: get most recent renewal data

### DIFF
--- a/src/endpoints/renewal/get_metahash.rs
+++ b/src/endpoints/renewal/get_metahash.rs
@@ -71,7 +71,6 @@ pub async fn handler(
                 let mut headers = HeaderMap::new();
                 headers.insert("Cache-Control", HeaderValue::from_static("max-age=30"));
 
-                println!("docs: {:?}", documents);
                 for doc in documents {
                     if let Ok(meta_hash) = doc.get_str("meta_hash") {
                         let mut tax_rate = 0.0;

--- a/src/endpoints/renewal/get_renewal_data.rs
+++ b/src/endpoints/renewal/get_renewal_data.rs
@@ -8,7 +8,7 @@ use axum::{
     response::{IntoResponse, Json},
 };
 use futures::StreamExt;
-use mongodb::bson::doc;
+use mongodb::{bson::doc, options::FindOptions};
 use serde::{Deserialize, Serialize};
 use starknet::core::types::FieldElement;
 use std::sync::Arc;
@@ -32,6 +32,11 @@ pub async fn handler(
         .starknetid_db
         .collection::<mongodb::bson::Document>("auto_renew_flows");
 
+    let find_options = FindOptions::builder()
+        .sort(doc! {"_cursor.from": -1})
+        .limit(1)
+        .build();
+
     let documents = renew_collection
         .find(
             doc! {
@@ -42,7 +47,7 @@ pub async fn handler(
                     { "_cursor.to": null },
                 ],
             },
-            None,
+            find_options,
         )
         .await;
 


### PR DESCRIPTION
This PR updated the `get_renewal_data` endpoint to fetch the most recent result indexed.