### PR TITLE
fix: improve get_non_subscribed_domains speed

### DIFF
--- a/src/endpoints/renewal/get_non_subscribed_domains.rs
+++ b/src/endpoints/renewal/get_non_subscribed_domains.rs
@@ -54,7 +54,8 @@ pub async fn handler(
                                     "$$local_id"
                                 ]
                             },
-                            "_cursor.to": null
+                            "root": true,
+                            "_cursor.to": null,
                         }
                     }
                 ],
@@ -78,7 +79,8 @@ pub async fn handler(
                         "$match": doc! {
                             "$expr": doc! {
                                 "$eq": ["$domain", "$$domain_name"]
-                            }
+                            },
+                            "_cursor.to": null
                         }
                     }
                 ],
@@ -125,6 +127,7 @@ pub async fn handler(
         Ok(mut cursor) => {
             let mut results: Vec<String> = Vec::new();
             while let Some(doc) = cursor.next().await {
+                println!("doc: {:?}", doc);
                 if let Ok(doc) = doc {
                     let enabled = doc.get_bool("enabled").unwrap_or(false);
                     if !enabled {

--- a/src/endpoints/renewal/get_non_subscribed_domains.rs
+++ b/src/endpoints/renewal/get_non_subscribed_domains.rs
@@ -127,7 +127,6 @@ pub async fn handler(
         Ok(mut cursor) => {
             let mut results: Vec<String> = Vec::new();
             while let Some(doc) = cursor.next().await {
-                println!("doc: {:?}", doc);
                 if let Ok(doc) = doc {
                     let enabled = doc.get_bool("enabled").unwrap_or(false);
                     if !enabled {


### PR DESCRIPTION
This PR update `get_non_subscribed_domains` pipeline to make it more efficient and avoid timeouts.