### PR TITLE
ref: update get_renewal_data to return all entries

### DIFF
--- a/src/endpoints/renewal/get_renewal_data.rs
+++ b/src/endpoints/renewal/get_renewal_data.rs
@@ -8,7 +8,7 @@ use axum::{
     response::{IntoResponse, Json},
 };
 use axum_auto_routes::route;
-use futures::StreamExt;
+use futures::TryStreamExt;
 use mongodb::bson::doc;
 use serde::{Deserialize, Serialize};
 use starknet::core::types::FieldElement;
@@ -34,41 +34,36 @@ pub async fn handler(
     State(state): State<Arc<AppState>>,
     Query(query): Query<StarknetIdQuery>,
 ) -> impl IntoResponse {
-    let result_auto_renew_flows = find_renewal_data(&state, "auto_renew_flows", &query).await;
+    // Fetch data from both collections and combine the results
+    let auto_renew_flows_future = find_renewal_data(&state, "auto_renew_flows", &query);
+    let auto_renew_flows_altcoins_future = find_renewal_data(&state, "auto_renew_flows_altcoins", &query);
 
-    let mut document_to_return = None;
+    let (auto_renew_flows, auto_renew_flows_altcoins) = futures::join!(
+        auto_renew_flows_future,
+        auto_renew_flows_altcoins_future
+    );
 
-    if let Ok(Some(doc)) = result_auto_renew_flows {
-        if doc.get_bool("enabled").unwrap_or(true) {
-            // If enabled is true, return this document
-            document_to_return = Some(doc);
-        } else {
-            // If enabled is false, check auto_renew_flows_altcoins but keep this document as a fallback.
-            let result_altcoins = find_renewal_data(&state, "auto_renew_flows_altcoins", &query)
-                .await
-                .ok()
-                .flatten();
-            document_to_return = result_altcoins.or(Some(doc)); // Use the altcoins result or fallback to the original document.
-        }
-    } else {
-        let result_altcoins = find_renewal_data(&state, "auto_renew_flows_altcoins", &query)
-                .await
-                .ok()
-                .flatten();
-            // we return this document
-            document_to_return = result_altcoins;
+    let mut combined_results = Vec::new();
+
+    if let Ok(results) = auto_renew_flows {
+        combined_results.extend(results);
+    }
+
+    if let Ok(results) = auto_renew_flows_altcoins {
+        combined_results.extend(results);
     }
 
     let mut headers = HeaderMap::new();
     headers.insert("Cache-Control", HeaderValue::from_static("max-age=30"));
 
-    match document_to_return {
-        Some(mut doc) => {
+    if !combined_results.is_empty() {
+        for doc in &mut combined_results {
             doc.remove("_id");
             doc.remove("_cursor");
-            (StatusCode::OK, headers, Json(doc)).into_response()
         }
-        None => get_error("Error while fetching from database or no results found".to_string()),
+        (StatusCode::OK, headers, Json(combined_results)).into_response()
+    } else {
+        get_error("Error while fetching from database or no results found".to_string())
     }
 }
 
@@ -76,15 +71,10 @@ async fn find_renewal_data(
     state: &AppState,
     collection_name: &str,
     query: &StarknetIdQuery,
-) -> mongodb::error::Result<Option<mongodb::bson::Document>> {
+) -> mongodb::error::Result<Vec<mongodb::bson::Document>> {
     let collection = state
         .starknetid_db
         .collection::<mongodb::bson::Document>(collection_name);
-
-    let find_options = mongodb::options::FindOptions::builder()
-        .sort(doc! {"_cursor.from": -1})
-        .limit(1)
-        .build();
 
     let mut cursor = collection
         .find(
@@ -96,9 +86,14 @@ async fn find_renewal_data(
                     { "_cursor.to": null },
                 ],
             },
-            find_options,
+            None,
         )
         .await?;
 
-    Ok(cursor.next().await.transpose()?)
+    let mut documents = Vec::new();
+    while let Some(result) = cursor.try_next().await? {
+        documents.push(result);
+    }
+
+    Ok(documents)
 }


### PR DESCRIPTION
This PR updates `get_renewal_data` endpoint to return all entries for a user address, a domain name (for _cursor.to = null) in `auto_renew_flows` and `auto_renew_flows_altcoins`. This is in case someone enables twice an autorenewal for his domain, with this data I'll be able to make a multicall of disable renewals in the identity page. This case should not happen, but if I missed something in the front it will solve it.  