### PR TITLE
Fix/resolving

### DIFF
--- a/src/endpoints/renewal/get_renewal_data.rs
+++ b/src/endpoints/renewal/get_renewal_data.rs
@@ -36,7 +36,7 @@ pub async fn handler(
 ) -> impl IntoResponse {
     let result_auto_renew_flows = find_renewal_data(&state, "auto_renew_flows", &query).await;
 
-    let mut document_to_return = None;
+    let document_to_return;
 
     if let Ok(Some(doc)) = result_auto_renew_flows {
         if doc.get_bool("enabled").unwrap_or(true) {
@@ -52,11 +52,11 @@ pub async fn handler(
         }
     } else {
         let result_altcoins = find_renewal_data(&state, "auto_renew_flows_altcoins", &query)
-                .await
-                .ok()
-                .flatten();
-            // we return this document
-            document_to_return = result_altcoins;
+            .await
+            .ok()
+            .flatten();
+        // we return this document
+        document_to_return = result_altcoins;
     }
 
     let mut headers = HeaderMap::new();

--- a/src/endpoints/renewal/get_renewal_data.rs
+++ b/src/endpoints/renewal/get_renewal_data.rs
@@ -36,35 +36,11 @@ pub async fn handler(
 ) -> impl IntoResponse {
     // Fetch data from both collections and combine the results
     let auto_renew_flows_future = find_renewal_data(&state, "auto_renew_flows", &query);
-    let auto_renew_flows_altcoins_future = find_renewal_data(&state, "auto_renew_flows_altcoins", &query);
+    let auto_renew_flows_altcoins_future =
+        find_renewal_data(&state, "auto_renew_flows_altcoins", &query);
 
-    let document_to_return;
-
-    if let Ok(Some(doc)) = result_auto_renew_flows {
-        if doc.get_bool("enabled").unwrap_or(true) {
-            // If enabled is true, return this document
-            document_to_return = Some(doc);
-        } else {
-            // If enabled is false, check auto_renew_flows_altcoins but keep this document as a fallback.
-            let result_altcoins = find_renewal_data(&state, "auto_renew_flows_altcoins", &query)
-                .await
-                .ok()
-                .flatten();
-            document_to_return = result_altcoins.or(Some(doc)); // Use the altcoins result or fallback to the original document.
-        }
-    } else {
-        let result_altcoins = find_renewal_data(&state, "auto_renew_flows_altcoins", &query)
-            .await
-            .ok()
-            .flatten();
-        // we return this document
-        document_to_return = result_altcoins;
-    }
-
-    let (auto_renew_flows, auto_renew_flows_altcoins) = futures::join!(
-        auto_renew_flows_future,
-        auto_renew_flows_altcoins_future
-    );
+    let (auto_renew_flows, auto_renew_flows_altcoins) =
+        futures::join!(auto_renew_flows_future, auto_renew_flows_altcoins_future);
 
     let mut combined_results = Vec::new();
 


### PR DESCRIPTION
This fixes the resolving of some domains in `domain_to_addr`. Since the Cairo 2 upgrade we now first check if there is a legacy target address, if there is none we check what is written on the identity. If nothing is written on the identity, we should check the owner of the domain, which was not done. This pull request fixes it. I also fixed a small warning by replacing a let mut by a simple let.

closes: https://github.com/starknet-id/api.starknet.id/issues/67