### PR TITLE
Feat/custom resolution rev

### DIFF
--- a/src/endpoints/domain_to_addr.rs
+++ b/src/endpoints/domain_to_addr.rs
@@ -52,7 +52,8 @@ pub async fn handler(
                     doc! {
                         "domain_slice" : prefix,
                         "resolver" : resolver,
-                        "field" : "starknet",
+                        // means "starknet"
+                        "field" : "0x000000000000000000000000000000000000000000000000737461726b6e6574",
                         "_cursor.to": null,
                     },
                     None,


### PR DESCRIPTION
This pull request adds support for custom resolutions in reverse resolving. This allows our API to find the main domain of someone who has a `.xplorer.stark` or a `.braavos.stark` for example. It does so by changing the `create_normal_pipeline` so after finding a matching reverse domain it extracts the root domain (which means we don't  support 2 or 3 levels of subdomains for this usecase yet) and finds a matching resolver to check what's its target.

closes #75 