### PR TITLE
fix: missing some reversed addresses

### DIFF
--- a/src/endpoints/addr_to_domain.rs
+++ b/src/endpoints/addr_to_domain.rs
@@ -322,7 +322,7 @@ fn create_main_id_pipeline(address: &String) -> Vec<Document> {
             "let": { "id": "$id" },
             "pipeline": [
                 doc! { "$match": {
-                    "_cursor.to": { "$exists": false },
+                    "_cursor.to": null,
                     "$expr": { "$eq": ["$id", "$$id"] }
                 } }
             ],


### PR DESCRIPTION
This pull request fixes a bug found by Nethermind team where some domains (like `prix0007.stark`) would not be displayed as main domain by the API because the field _cursor.to was equal to null (and not not set). Matching null supports both so I replaced exist : false by _cursor.to = null.