### PR TITLE
fix: social networks not showing on ENS page

### DIFF
--- a/config.template.toml
+++ b/config.template.toml
@@ -94,16 +94,16 @@ arbitrum = 2147525809
 [evm_records_verifiers]
 
 [evm_records_verifiers."com.discord"]
-verifier_contract = "0x0182EcE8173C216A395f4828e1523541b7e3600bf190CB252E1a1A0cE219d184"
+verifier_contracts = ["0x0182EcE8173C216A395f4828e1523541b7e3600bf190CB252E1a1A0cE219d184"]
 field = "discord"
 handler = "GetDiscordName"
 
 [evm_records_verifiers."com.github"]
-verifier_contract = "0x0182EcE8173C216A395f4828e1523541b7e3600bf190CB252E1a1A0cE219d184"
+verifier_contracts = ["0x0182EcE8173C216A395f4828e1523541b7e3600bf190CB252E1a1A0cE219d184"]
 field = "github"
 handler = "GetGithubName"
 
 [evm_records_verifiers."com.twitter"]
-verifier_contract = "0x0182EcE8173C216A395f4828e1523541b7e3600bf190CB252E1a1A0cE219d184"
+verifier_contracts = ["0x0182EcE8173C216A395f4828e1523541b7e3600bf190CB252E1a1A0cE219d184"]
 field = "twitter"
 handler = "GetTwitterName"

--- a/src/config.rs
+++ b/src/config.rs
@@ -104,7 +104,7 @@ pub_struct!(Clone, Debug, Deserialize; Evm {
 pub struct OffchainResolvers(HashMap<String, OffchainResolver>);
 
 pub_struct!(Clone, Debug, Deserialize; EvmRecordVerifier {
-    verifier_contract: FieldElement,
+    verifier_contracts: Vec<FieldElement>,
     field: String,
     handler: HandlerType,
 });


### PR DESCRIPTION
Close #87 
Bug is caused by the wrong env variables for the social networks verifier contracts in the mainnet config file. Currently we have the sepolia contracts instead of the mainnet ones.

As there are 2 verifiers contracts, I added support for multiple verifier contracts.

Env variables are updated in the sepolia config file, but not yet on mainnet, we'll need to update it before deployment to : 
```
verifier_contracts = [
    "0x002d5f0f2fcba62a54f0d8a73fb2e437d76c53f7297153b2afd1f198af6d12aa",
    "0x07d14dfd8ee95b41fce179170d88ba1f0d5a512e13aeb232f19cfeec0a88f8bf",
]
```