### PR TITLE
fix: using vercel functions for generating identicons

### DIFF
--- a/src/endpoints/crosschain/ethereum/utils.rs
+++ b/src/endpoints/crosschain/ethereum/utils.rs
@@ -362,7 +362,7 @@ pub async fn get_profile_picture_uri(
     match uri {
         Some(u) if u.contains("base64") => Some(parse_base64_image(u)),
         Some(u) => Some(fetch_image_url(config, u).await),
-        None if use_default_pfp => Some(format!("https://starknet.id/api/identicons/{}", id)),
+        None if use_default_pfp => Some(format!("https://identicon.starknet.id/{}", id)),
         _ => None,
     }
 }

--- a/src/endpoints/uri.rs
+++ b/src/endpoints/uri.rs
@@ -145,7 +145,7 @@ pub async fn handler(
                 description: "This token represents an identity on StarkNet.".to_string(),
                 image: match img_url {
                     Some(url) => url,
-                    None => format!("https://starknet.id/api/identicons/{}", &query.id),
+                    None => format!("https://identicon.starknet.id/{}", &query.id),
                 },
                 expiry: Some(expiry),
                 attributes: Some(vec![
@@ -171,7 +171,7 @@ pub async fn handler(
             let token_uri = TokenURI {
                 name: format!("Starknet ID: {}", &query.id),
                 description: "This token represents an identity on StarkNet.".to_string(),
-                image: format!("https://starknet.id/api/identicons/{}", &query.id),
+                image: format!("https://identicon.starknet.id/{}", &query.id),
                 expiry: None,
                 attributes: None,
             };


### PR DESCRIPTION
This pull request replaces calls to starknet.id/api/ for generating identicons to our selfdeployed server, this should save us a lot of vercel invocations.