### PR TITLE
fix: only match domains without resolver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,32 +10,32 @@ starknet = { git = "https://github.com/xJonathanLEI/starknet-rs", rev = "c974e5c
 starknet-id = { git = "https://github.com/starknet-id/starknetid.rs", rev = "2b30c2453b96789a628c86d2edebb1023fa2e77d" }
 starknet-crypto = { git = "https://github.com/xJonathanLEI/starknet-rs", rev = "c974e5cb42e8d8344cee910b76005ec46b4dd3ed", package = "starknet-crypto" }
 axum_auto_routes = { git = "https://github.com/Th0rgal/axum_auto_routes.git", rev = "f9e1d2083e887cd264642359c4aa851938da6f09" }
-axum = "0.6.18"
-futures = "0.3.28"
-mongodb = "2.5.0"
-serde = { version = "1.0.163", features = ["derive"] }
-serde_json = "1.0.96"
-tokio = { version = "1.28.1", features = ["macros", "rt-multi-thread"] }
-toml = "0.7.4"
-tower-http = { version = "0.4.0", features = ["cors"] }
-chrono = "0.4.24"
-reqwest = { version = "0.11.20", features = ["json"] }
+axum = "0.6.20"
+futures = "0.3.30"
+mongodb = "2.8.2"
+serde = { version = "1.0.209", features = ["derive"] }
+serde_json = "1.0.127"
+tokio = { version = "1.40.0", features = ["macros", "rt-multi-thread"] }
+toml = "0.7.8"
+tower-http = { version = "0.4.4", features = ["cors"] }
+chrono = "0.4.38"
+reqwest = { version = "0.11.27", features = ["json"] }
 ark-ff = "0.4.2"
 hex = "0.4.3"
 error-stack = "0.4.1"
-anyhow = "1.0.75"
-lazy_static = "1.4.0"
-regex = "1.10.2"
-bs58 = "0.5.0"
-ed25519-dalek = "2.1.0"
-ctor = "0.2.6"
+anyhow = "1.0.86"
+lazy_static = "1.5.0"
+regex = "1.10.6"
+bs58 = "0.5.1"
+ed25519-dalek = "2.1.1"
+ctor = "0.2.8"
 base64 = "0.22.1"
-solana-sdk = "1.18.12"
+solana-sdk = "1.18.23"
 bincode = "1.3.3"
 ethabi = "18.0.0"
 ethers = "2.0.14"
 serde_urlencoded = "0.7.1"
-bytes = "1.6.0"
+bytes = "1.7.1"
 crypto-bigint = "0.5.5"
 rand = "0.8.5"
 

--- a/src/endpoints/addr_to_domain.rs
+++ b/src/endpoints/addr_to_domain.rs
@@ -32,16 +32,17 @@ pub struct AddrToDomainQuery {
 }
 
 async fn read_cursor(mut cursor: Cursor<Document>) -> Result<AddrToDomainData> {
-    while let Some(result) = cursor.next().await {
+    if let Some(result) = cursor.next().await {
         let doc = result?;
         let domain = doc.get_str("domain").unwrap_or_default().to_owned();
         let domain_expiry = doc.get_i64("domain_expiry").ok();
-        return Ok(AddrToDomainData {
+        Ok(AddrToDomainData {
             domain,
             domain_expiry,
-        });
+        })
+    } else {
+        bail!("No document found for the given address")
     }
-    bail!("No document found for the given address")
 }
 
 async fn aggregate_data(


### PR DESCRIPTION
Hotfix for custom resolver domains that would resolve to my address. Actually what happened is that instead of just not resolving at all, the query would match many documents and take the first one. I fixed it by making sure we only match domains with no custom resolvers in the naive resolver part.

before `b.gg.stark` :
```json
{"addr":"0x00a00373a00352aa367058555149b573322910d54fcdf3a926e3e56d0dcb4b0c","domain_expiry":null}
```

now:
404
```
No document found for the given domain
```