### PR TITLE
Prevent blocking on Starkscan API by enforcing timeout

### DIFF
--- a/src/endpoints/addr_to_full_ids.rs
+++ b/src/endpoints/addr_to_full_ids.rs
@@ -18,7 +18,6 @@ use mongodb::{
 use serde::{Deserialize, Serialize};
 use starknet::core::types::FieldElement;
 use std::sync::Arc;
-use tokio::time::timeout;
 
 #[derive(Serialize, Deserialize)]
 pub struct FullId {
@@ -220,7 +219,7 @@ pub async fn handler(
                         let pp_url = match &id.pp_url_info {
                             Some((contract, id)) => {
                                 match tokio::time::timeout(
-                                    std::time::Duration::from_secs(10),
+                                    std::time::Duration::from_secs(5),
                                     fetch_img_url(
                                         &api_url_clone,
                                         &api_key_clone,

--- a/src/endpoints/addr_to_full_ids.rs
+++ b/src/endpoints/addr_to_full_ids.rs
@@ -18,6 +18,7 @@ use mongodb::{
 use serde::{Deserialize, Serialize};
 use starknet::core::types::FieldElement;
 use std::sync::Arc;
+use tokio::time::timeout;
 
 #[derive(Serialize, Deserialize)]
 pub struct FullId {
@@ -218,13 +219,20 @@ pub async fn handler(
                     async move {
                         let pp_url = match &id.pp_url_info {
                             Some((contract, id)) => {
-                                fetch_img_url(
-                                    &api_url_clone,
-                                    &api_key_clone,
-                                    contract.to_owned(),
-                                    id.to_owned(),
+                                match tokio::time::timeout(
+                                    std::time::Duration::from_secs(10),
+                                    fetch_img_url(
+                                        &api_url_clone,
+                                        &api_key_clone,
+                                        contract.to_owned(),
+                                        id.to_owned(),
+                                    ),
                                 )
                                 .await
+                                {
+                                    Ok(result) => result,
+                                    Err(_) => None,
+                                }
                             }
                             None => None,
                         };


### PR DESCRIPTION
closes #135 , wrapped fetch_img_url() in a timeout (e.g., 10 seconds) and ignored if it takes too long, allowing the rest of the process to continue without interruption.